### PR TITLE
Fix #34 and update models to download

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,2 +1,2 @@
 import launch
-launch.git_clone("https://github.com/isl-org/MiDaS.git", "repositories/midas", "midas","f28885afc4c6c8907e0555b00e28b299ba2e5a16")
+launch.git_clone("https://github.com/isl-org/MiDaS.git", "repositories/midas", "midas")

--- a/scripts/multirender.py
+++ b/scripts/multirender.py
@@ -32,11 +32,17 @@ class Script(scripts.Script):
         if is_img2img: return
         txt2img_samplers_names = [s.name for s in sd_samplers.samplers]
         img2img_samplers_names = [s.name for s in sd_samplers.samplers_for_img2img]
-        midas_models = ["midas_v21_small","midas_v21","dpt_hybrid","dpt_large"]
+        midas_models = ["midas_v21_small","dpt_swin2_tiny_256","dpt_swin2_large_384","dpt_beit_large_512"]
         
         #pick model
         with gr.Box():
-            foregen_midas_model = gr.Dropdown(label="MiDaS model (midas_v21_small - smallest and fastest > dpt_large - higher quality, biggest and slowest)", choices=midas_models, value="midas_v21_small")
+            with gr.Box():
+                gr.Markdown(
+                """
+                #### ATTENTION! Largest model (dpt_beit_large_512) weighs 1.5 GB, it will take A WHILE to download.
+
+                """)
+            foregen_midas_model = gr.Dropdown(label="MiDaS model (models are ordered from smallest and least accurate (midas_v21_small) to biggest and most accurate (dpt_beit_large_512))", choices=midas_models, value="midas_v21_small")
         
         # foreground UI
         with gr.Box():

--- a/scripts/multirender.py
+++ b/scripts/multirender.py
@@ -187,8 +187,7 @@ class Script(scripts.Script):
         o_width     = p.width
         o_height    = p.height
         o_denoising_strength = p.denoising_strength
-        o_firstphase_width   = p.firstphase_width
-        o_firstphase_height  = p.firstphase_height
+
 
         n_iter=p.n_iter
         for j in range(n_iter):
@@ -209,8 +208,7 @@ class Script(scripts.Script):
             p.width = o_width
             p.height = o_height
             p.denoising_strength = o_denoising_strength
-            p.firstphase_width = o_firstphase_width
-            p.firstphase_height = o_firstphase_height
+
             proc = process_images(p)
             background_image = proc.images[0]
 
@@ -234,8 +232,7 @@ class Script(scripts.Script):
                 p.width     = foregen_size_x
                 p.height    = foregen_size_y
                 p.denoising_strength  = None
-                p.firstphase_width    = None
-                p.firstphase_height   = None
+
                 proc = process_images(p)
                 foregrounds.append(proc.images[0])
 

--- a/scripts/simple_depthmap.py
+++ b/scripts/simple_depthmap.py
@@ -35,25 +35,25 @@ class SimpleDepthMapGenerator(object):
         os.makedirs(model_dir, exist_ok=True)
         print("Loading midas model weights ..")
 
-        if self.chosen_model == "dpt_large":
-            model_path = f"{model_dir}/dpt_large-midas-2f21e586.pt"
-        elif self.chosen_model == "dpt_hybrid":
-            model_path = f"{model_dir}/dpt_hybrid-midas-501f0c75.pt"
+        if self.chosen_model == "dpt_beit_large_512":
+            model_path = f"{model_dir}/dpt_beit_large_512.pt"
+        elif self.chosen_model == "dpt_swin2_large_384":
+            model_path = f"{model_dir}/dpt_swin2_large_384.pt"
         elif self.chosen_model == "midas_v21_small":
             model_path = f"{model_dir}/midas_v21_small-70d6b9c8.pt"
-        elif self.chosen_model == "midas_v21":
-            model_path = f"{model_dir}/midas_v21-f6b98070.pt"
+        elif self.chosen_model == "dpt_swin2_tiny_256":
+            model_path = f"{model_dir}/dpt_swin2_tiny_256.pt"
         print(model_path)
 
         if not os.path.exists(model_path):
-            if self.chosen_model == "dpt_large":
-                download_file(model_path,"https://github.com/isl-org/MiDaS/releases/download/v3/dpt_large-midas-2f21e586.pt")
-            elif self.chosen_model == "dpt_hybrid":
-                download_file(model_path,"https://github.com/isl-org/MiDaS/releases/download/v3/dpt_hybrid-midas-501f0c75.pt")
+            if self.chosen_model == "dpt_beit_large_512":
+                download_file(model_path,"https://github.com/isl-org/MiDaS/releases/download/v3_1/dpt_beit_large_512.pt")
+            elif self.chosen_model == "dpt_swin2_large_384":
+                download_file(model_path,"https://github.com/isl-org/MiDaS/releases/download/v3_1/dpt_swin2_large_384.pt")
             elif self.chosen_model == "midas_v21_small":
                 download_file(model_path,"https://github.com/isl-org/MiDaS/releases/download/v2_1/midas_v21_small-70d6b9c8.pt")
-            elif self.chosen_model == "midas_v21":
-                download_file(model_path,"https://github.com/isl-org/MiDaS/releases/download/v2_1/midas_v21-f6b98070.pt")
+            elif self.chosen_model == "dpt_swin2_tiny_256":
+                download_file(model_path,"https://github.com/isl-org/MiDaS/releases/download/v3_1/dpt_swin2_tiny_256.pt")
             
 
 
@@ -63,41 +63,37 @@ class SimpleDepthMapGenerator(object):
             print("device: %s" % device)
 
             model_dir = "./models/midas"
-            if self.chosen_model == "dpt_large":
-                model_path = f"{model_dir}/dpt_large-midas-2f21e586.pt"
-            elif self.chosen_model == "dpt_hybrid":
-                model_path = f"{model_dir}/dpt_hybrid-midas-501f0c75.pt"
+            if self.chosen_model == "dpt_beit_large_512":
+                model_path = f"{model_dir}/dpt_beit_large_512.pt"
+            elif self.chosen_model == "dpt_swin2_large_384":
+                model_path = f"{model_dir}/dpt_swin2_large_384.pt"
             elif self.chosen_model == "midas_v21_small":
                 model_path = f"{model_dir}/midas_v21_small-70d6b9c8.pt"
-            elif self.chosen_model == "midas_v21":
-                model_path = f"{model_dir}/midas_v21-f6b98070.pt"
+            elif self.chosen_model == "dpt_swin2_tiny_256":
+                model_path = f"{model_dir}/dpt_swin2_tiny_256.pt"
 
             #load model
-            if self.chosen_model == "dpt_large": # DPT-Large
+            #taken directly from:
+            #https://github.com/isl-org/MiDaS/blob/master/midas/model_loader.py
+            if self.chosen_model == "dpt_beit_large_512":
                 model = DPTDepthModel(
                     path=model_path,
-                    backbone="vitl16_384",
+                    backbone="beitl16_512",
                     non_negative=True,
                 )
-                net_w, net_h = 384, 384
+                net_w, net_h = 512, 512
                 resize_mode = "minimal"
                 normalization = NormalizeImage(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
-            elif self.chosen_model == "dpt_hybrid": #DPT-Hybrid
+            elif self.chosen_model == "dpt_swin2_large_384":
                 model = DPTDepthModel(
                     path=model_path,
-                    backbone="vitb_rn50_384",
+                    backbone="swin2l24_384",
                     non_negative=True,
                 )
                 net_w, net_h = 384, 384
-                resize_mode="minimal"
+                keep_aspect_ratio = False
+                resize_mode = "minimal"
                 normalization = NormalizeImage(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
-            elif self.chosen_model == "midas_v21":
-                model = MidasNet(model_path, non_negative=True)
-                net_w, net_h = 384, 384
-                resize_mode="upper_bound"
-                normalization = NormalizeImage(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                )
             elif self.chosen_model == "midas_v21_small":
                 model = MidasNet_small(model_path, features=64, backbone="efficientnet_lite3", exportable=True, non_negative=True, blocks={'expand': True})
                 net_w, net_h = 256, 256
@@ -105,6 +101,13 @@ class SimpleDepthMapGenerator(object):
                 normalization = NormalizeImage(
                     mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
                 )
+            elif self.chosen_model == "dpt_swin2_tiny_256":
+                model = DPTDepthModel(path=model_path,backbone="swin2t16_256",non_negative=True,)
+                net_w, net_h = 256, 256
+                keep_aspect_ratio = False
+                resize_mode = "minimal"
+                normalization = NormalizeImage(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
+
             # init transform
             transform = Compose(
                 [


### PR DESCRIPTION
Fixes #34.

Reverts specifying midas repo commit, as it is no longer needed and was added in last pr by accident (sorry).

Replace midas models with newer ones. (I'm keeping v2.1 small model because it was default before)